### PR TITLE
Improve module importability

### DIFF
--- a/f8a_version_comparator/__init__.py
+++ b/f8a_version_comparator/__init__.py
@@ -16,3 +16,13 @@
 #
 
 """Initialize Module."""
+
+__all__ = [
+    "base",
+    "comparable_version",
+    "item_object",
+]
+
+from . import base
+from . import comparable_version
+from . import item_object


### PR DESCRIPTION
- Modules are now directly accessible from top level package
- It is now possible to import all package modules using * operator

Before the modules were _only_ accessible as:
```python
from f8a_version_comparator import base, comparable_version
base(...)
comparable_version(...)
```

The PR introduces:
```python
import f8a_version_comparator as vc
vc.base(...)
vc.comparable_version(...)
```

or 

```python
from f8a_version_comparator import *
base(...)
comparable_version(...)
```

Non of which was possible before.

<br>

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   f8a_version_comparator/\_\_init\_\_.py